### PR TITLE
when working with arrays should use splice to remove elements

### DIFF
--- a/TileLayer.GeoJSON.js
+++ b/TileLayer.GeoJSON.js
@@ -90,7 +90,7 @@ L.TileLayer.GeoJSON = L.TileLayer.Ajax.extend({
                     for (var f in tileDatum.features) {
                         var featureKey = this.options.unique(tileDatum.features[f]);
                         if (this._uniqueKeys.hasOwnProperty(featureKey)) {
-                            delete tileDatum.features[f];
+                            tileDatum.features.splice(f, 1);
                         }
                         else {
                             this._uniqueKeys[featureKey] = featureKey;


### PR DESCRIPTION
If you use delete on an array it doesnt update the index, so you have undefined elements, and a inaccurate length. Array.splice should be used to remove elements from arrays.

Without this change leaflet throws an error when adding the layer while iterating through the features array if features have been deleted instead of removed with splice. 
