### PR TITLE
Set incomingLayer.feature even when adding subsequent parts to a collection.

### DIFF
--- a/TileLayer.GeoJSON.js
+++ b/TileLayer.GeoJSON.js
@@ -200,6 +200,7 @@ L.TileLayer.GeoJSON = L.TileLayer.Ajax.extend({
                 return this;
             }
 
+            incomingLayer.feature = L.GeoJSON.asFeature(geojson);
             // Add the incoming Layer to existing key's GeometryCollection
             if (key in this._keyLayers) {
                 parentLayer = this._keyLayers[key];
@@ -207,7 +208,6 @@ L.TileLayer.GeoJSON = L.TileLayer.Ajax.extend({
             }
             // Convert the incoming GeoJSON feature into a new GeometryCollection layer
             else {
-                incomingLayer.feature = L.GeoJSON.asFeature(geojson);
                 this._keyLayers[key] = incomingLayer;
             }
         }


### PR DESCRIPTION
If the `style` parameter is a function, then that function is supposed to be passed the GeoJSON feature every time it is called. But if you create a layer with a `unique` function, so that features are grouped into collections, the `style` function only receives the feature the first time it is called for each collection, and styling of the subsequent parts added to the collection doesn't work. I believe this patch fixes this problem.
