### PR TITLE
Update TileLayer.GeoJSON.js

### DIFF
--- a/TileLayer.GeoJSON.js
+++ b/TileLayer.GeoJSON.js
@@ -39,7 +39,7 @@ L.TileLayer.Ajax = L.TileLayer.extend({
         this._requests = [];
     },
     _update: function () {
-        if (this._map._panTransition && this._map._panTransition._inProgress) { return; }
+        if (this._map && this._map._panTransition && this._map._panTransition._inProgress) { return; }
         if (this._tilesToLoad < 0) { this._tilesToLoad = 0; }
         L.TileLayer.prototype._update.apply(this, arguments);
     }


### PR DESCRIPTION
When removing a layer while zooming, this._map might be null while _update would still be called
