### PR TITLE
Only iterate over numeric keys of _requests array

### DIFF
--- a/TileLayer.GeoJSON.js
+++ b/TileLayer.GeoJSON.js
@@ -33,7 +33,7 @@ L.TileLayer.Ajax = L.TileLayer.extend({
     },
     _reset: function () {
         L.TileLayer.prototype._reset.apply(this, arguments);
-        for (var i in this._requests) {
+        for (var i = 0; i < this._requests.length; i++) {
             this._requests[i].abort();
         }
         this._requests = [];


### PR DESCRIPTION
Fixes "TypeError: this._requests[i].abort is not a function" when non-numeric properties are inherited from the prototype chain.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in

Encountered this using the tilelayer inside an Ember.js component with the ember debug extension which adds a `_super` property to the Array prototype and causes the above error.