### PR TITLE
Ignoring HTTP 204

### DIFF
--- a/TileLayer.GeoJSON.js
+++ b/TileLayer.GeoJSON.js
@@ -13,7 +13,7 @@ L.TileLayer.Ajax = L.TileLayer.extend({
                 return;
             }
             var s = req.status;
-            if ((s >= 200 && s < 300) || s === 304) {
+            if ((s >= 200 && s < 300 && s != 204) || s === 304) {
                 tile.datum = JSON.parse(req.responseText);
                 layer._tileLoaded(tile, tilePoint);
             } else {


### PR DESCRIPTION
When the tile doesn't have data, it has an error. We use 204 to Show the tilelayer that it's empty. So i think you should ignore 204. I'm not sure if this is the correct way to ignore it. But it's how i fixed it in my Code. Thank you for this cool  Library